### PR TITLE
fix : US7에서 사용자의 카풀 조회시 자신의 카풀에 탑승해 있는 탑승자 명단 추가

### DIFF
--- a/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
@@ -93,7 +93,7 @@ public class TicketController {
           @ApiResponse(responseCode = "200", description = "유저 카풀 조회 성공", content = @Content(schema = @Schema(implementation = TicketDetailResponseDto.class))),
           @ApiResponse(responseCode = "404", description = "존재하지 않는 카풀", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
   @GetMapping("/promise")
-  public MyTicketDetailResponseDto promise(@AuthenticationPrincipal UserDetails userDetails) {
+  public TicketDetailResponseDto promise(@AuthenticationPrincipal UserDetails userDetails) {
       long memberId = Long.parseLong(userDetails.getUsername());
       if(!memberUseCase.checkRole(memberId))
         throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getMessage(), ErrorCode.MEMBER_NOT_AUTHORITY);

--- a/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
@@ -4,10 +4,7 @@ import com.example.eunboard.member.application.port.in.MemberUseCase;
 import com.example.eunboard.shared.exception.ErrorCode;
 import com.example.eunboard.shared.exception.ErrorResponse;
 import com.example.eunboard.shared.exception.custom.CustomException;
-import com.example.eunboard.ticket.application.port.in.TicketCreateRequestDto;
-import com.example.eunboard.ticket.application.port.in.TicketDetailResponseDto;
-import com.example.eunboard.ticket.application.port.in.TicketShortResponseDto;
-import com.example.eunboard.ticket.application.port.in.TicketUseCase;
+import com.example.eunboard.ticket.application.port.in.*;
 import com.example.eunboard.ticket.domain.TicketStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -96,7 +93,7 @@ public class TicketController {
           @ApiResponse(responseCode = "200", description = "유저 카풀 조회 성공", content = @Content(schema = @Schema(implementation = TicketDetailResponseDto.class))),
           @ApiResponse(responseCode = "404", description = "존재하지 않는 카풀", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
   @GetMapping("/promise")
-  public TicketDetailResponseDto promise(@AuthenticationPrincipal UserDetails userDetails) {
+  public MyTicketDetailResponseDto promise(@AuthenticationPrincipal UserDetails userDetails) {
       long memberId = Long.parseLong(userDetails.getUsername());
       if(!memberUseCase.checkRole(memberId))
         throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getMessage(), ErrorCode.MEMBER_NOT_AUTHORITY);
@@ -129,7 +126,7 @@ public class TicketController {
           @ApiResponse(responseCode = "403", description = "권한이 없는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "404", description = "존재하지 않는 카풀", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
   @GetMapping("/update/{id}")
-  public void delete(@AuthenticationPrincipal UserDetails userDetails, @PathVariable long id, TicketStatus status) {
+  public void update(@AuthenticationPrincipal UserDetails userDetails, @PathVariable long id, TicketStatus status) {
     long memberId = Long.parseLong(userDetails.getUsername());
     if (!memberUseCase.checkRole(memberId))
       throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getMessage(), ErrorCode.MEMBER_NOT_AUTHORITY);

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/MyTicketDetailResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/MyTicketDetailResponseDto.java
@@ -1,0 +1,91 @@
+package com.example.eunboard.ticket.application.port.in;
+
+import com.example.eunboard.member.application.port.in.MemberResponseDTO;
+import com.example.eunboard.passenger.application.port.in.PassengerResponseDTO;
+import com.example.eunboard.passenger.domain.Passenger;
+import com.example.eunboard.ticket.domain.DayStatus;
+import com.example.eunboard.ticket.domain.Ticket;
+import com.example.eunboard.ticket.domain.TicketType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyTicketDetailResponseDto {
+
+    private Long id;
+    /**
+     * 드라이버 이름
+     */
+    private String memberName;
+    // 드라이버 이미지
+    private String profileImage;
+    // 출발지
+    private String startArea;
+    // 도착지
+    private String endArea;
+    // 월일
+    private String startDayMonth;
+    // 오전 오후
+    private DayStatus dayStatus;
+    // 출발 시간
+    private String startTime;
+    // 탑승 장소 상세
+    private String boardingPlace;
+    // 탑승 인원
+    private Integer recruitPerson;
+    // 유료 무료
+    private TicketType ticketType;
+    // 추후 사용?
+    private Long ticketPrice;
+    // 탑승자 명단
+    private List<MemberResponseDTO> passengers;
+
+    @Builder
+    public MyTicketDetailResponseDto(Long id, String memberName, String profileImage, String startArea, String endArea, String startDayMonth, DayStatus dayStatus, String startTime, String boardingPlace, Integer recruitPerson, TicketType ticketType, Long ticketPrice, List<MemberResponseDTO> passengers) {
+        this.id = id;
+        this.memberName = memberName;
+        this.profileImage = profileImage;
+        this.startArea = startArea;
+        this.endArea = endArea;
+        this.startDayMonth = startDayMonth;
+        this.dayStatus = dayStatus;
+        this.startTime = startTime;
+        this.boardingPlace = boardingPlace;
+        this.recruitPerson = recruitPerson;
+        this.ticketType = ticketType;
+        this.ticketPrice = ticketPrice;
+        this.passengers = passengers;
+    }
+
+
+    public static MyTicketDetailResponseDto toDTO(Ticket entity) {
+        String startDayTime = entity.getStartDtime();
+        // yyyy mmdd hhmm
+        String dayMonth = startDayTime.substring(4, 8);
+        String minuteHour = startDayTime.substring(8);
+        return MyTicketDetailResponseDto.builder()
+                .id(entity.getId()) // 예약 하기 하려면 있어야 될듯?
+                .startArea(entity.getStartArea())
+                .endArea(entity.getEndArea())
+                .profileImage(entity.getMember().getProfileImage())
+                .memberName(entity.getMember().getMemberName())
+                .dayStatus(entity.getDayStatus())
+                .startTime(minuteHour)
+                .startDayMonth(dayMonth)
+                .ticketType(entity.getTicketType())
+                .recruitPerson(entity.getRecruitPerson())
+                .boardingPlace(entity.getBoardingPlace())
+                // 탑승자에 대한 정보를 변환해서 반환해야함.
+                .passengers(entity.getPassengerList().stream()
+                        .map(Passenger::getMember)
+                        .map((member -> MemberResponseDTO.toDTO(member, null)))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
@@ -1,9 +1,14 @@
 package com.example.eunboard.ticket.application.port.in;
 
+import com.example.eunboard.member.application.port.in.MemberResponseDTO;
+import com.example.eunboard.passenger.domain.Passenger;
 import com.example.eunboard.ticket.domain.DayStatus;
 import com.example.eunboard.ticket.domain.Ticket;
 import com.example.eunboard.ticket.domain.TicketType;
 import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -35,6 +40,8 @@ public class TicketDetailResponseDto {
     private TicketType ticketType;
     // 추후 사용?
     private Long ticketPrice;
+    // 탑승자 명단
+    private List<MemberResponseDTO> passengers;
 
     public static TicketDetailResponseDto toDTO(Ticket entity) {
         String startDayTime = entity.getStartDtime();
@@ -53,6 +60,11 @@ public class TicketDetailResponseDto {
                 .ticketType(entity.getTicketType())
                 .recruitPerson(entity.getRecruitPerson())
                 .boardingPlace(entity.getBoardingPlace())
+                // 탑승자에 대한 정보를 변환해서 반환해야함.
+                .passengers(entity.getPassengerList().stream()
+                        .map(Passenger::getMember)
+                        .map((member -> MemberResponseDTO.toDTO(member, null)))
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketUseCase.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketUseCase.java
@@ -13,6 +13,6 @@ public interface TicketUseCase {
     TicketDetailResponseDto readTicket(Long id);
     // 티켓 상태 업데이트
     void ticketStatusUpdate(long memberId, long id, TicketStatus status);
-    TicketDetailResponseDto getPromise(Long memberId);
+    MyTicketDetailResponseDto getPromise(Long memberId);
     List<TicketDetailResponseDto> getPromises(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketUseCase.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketUseCase.java
@@ -13,6 +13,6 @@ public interface TicketUseCase {
     TicketDetailResponseDto readTicket(Long id);
     // 티켓 상태 업데이트
     void ticketStatusUpdate(long memberId, long id, TicketStatus status);
-    MyTicketDetailResponseDto getPromise(Long memberId);
+    TicketDetailResponseDto getPromise(Long memberId);
     List<TicketDetailResponseDto> getPromises(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
+++ b/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
@@ -73,14 +73,14 @@ public class TicketService implements TicketUseCase {
     }
 
     @Override
-    public MyTicketDetailResponseDto getPromise(Long memberId) {
+    public TicketDetailResponseDto getPromise(Long memberId) {
         Ticket ticket = ticketRepository.findByMember(Member.builder().memberId(memberId).build());
 
         if (ticket == null) {
             throw new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND);
         }
         
-        return MyTicketDetailResponseDto.toDTO(ticket);
+        return TicketDetailResponseDto.toDTO(ticket);
     }
 
     /**

--- a/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
+++ b/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
@@ -5,10 +5,7 @@ import com.example.eunboard.member.domain.Member;
 import com.example.eunboard.member.domain.MemberRole;
 import com.example.eunboard.shared.exception.ErrorCode;
 import com.example.eunboard.shared.exception.custom.CustomException;
-import com.example.eunboard.ticket.application.port.in.TicketCreateRequestDto;
-import com.example.eunboard.ticket.application.port.in.TicketDetailResponseDto;
-import com.example.eunboard.ticket.application.port.in.TicketShortResponseDto;
-import com.example.eunboard.ticket.application.port.in.TicketUseCase;
+import com.example.eunboard.ticket.application.port.in.*;
 import com.example.eunboard.ticket.application.port.out.TicketRepositoryPort;
 import com.example.eunboard.ticket.domain.Ticket;
 import com.example.eunboard.ticket.domain.TicketStatus;
@@ -76,14 +73,14 @@ public class TicketService implements TicketUseCase {
     }
 
     @Override
-    public TicketDetailResponseDto getPromise(Long memberId) {
+    public MyTicketDetailResponseDto getPromise(Long memberId) {
         Ticket ticket = ticketRepository.findByMember(Member.builder().memberId(memberId).build());
 
         if (ticket == null) {
             throw new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND);
         }
         
-        return TicketDetailResponseDto.toDTO(ticket);
+        return MyTicketDetailResponseDto.toDTO(ticket);
     }
 
     /**


### PR DESCRIPTION
- 기존에 ticket detail 정보조회 api를 보면 탑승자 정보를 제공하지 않습니다. 하지만 드라이버나 탑승자가 자신의 카풀을 조회할 때 현재 탑승자 목록을 같이 보여주어야하기 때문에 해당 부분을 추가해서 수정하였습니다.
- 혹시 제가 이해한 부분이 잘못되었거나 이미 기존에 구현되어있던 부분이 있을까요?