### PR TITLE
fix: 카카오 오픈 채팅 필드가 티켓 상세보기에서 누락되어서 해당 컬럼 DTO에 추가

### DIFF
--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
@@ -40,6 +40,8 @@ public class TicketDetailResponseDto {
     private TicketType ticketType;
     // 추후 사용?
     private Long ticketPrice;
+    // 오픈 카톡 주소
+    private String openChatUrl;
     // 탑승자 명단
     private List<MemberResponseDTO> passengers;
 
@@ -59,6 +61,7 @@ public class TicketDetailResponseDto {
                 .startDayMonth(dayMonth)
                 .ticketType(entity.getTicketType())
                 .recruitPerson(entity.getRecruitPerson())
+                .openChatUrl(entity.getOpenChatUrl())
                 .boardingPlace(entity.getBoardingPlace())
                 // 탑승자에 대한 정보를 변환해서 반환해야함.
                 .passengers(entity.getPassengerList().stream()


### PR DESCRIPTION
- 오픈 채팅방 url이 DTO에서 누락되어서 해당 필드 추가