### PR TITLE
refactor, feat : 카풀 도메인에 대한 Swagger 조회 허용 및 탑승자 삭제 API POST->DELETE로 …

### DIFF
--- a/src/main/java/com/example/eunboard/passenger/adapter/in/PassengerController.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/in/PassengerController.java
@@ -4,42 +4,59 @@ import com.example.eunboard.passenger.application.port.in.PassengerCreateRequest
 import com.example.eunboard.passenger.application.port.in.PassengerDeleteRequestDTO;
 import com.example.eunboard.passenger.application.port.in.PassengerUseCase;
 import com.example.eunboard.shared.common.CommonResponse;
+import com.example.eunboard.shared.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/ride")
+@RequestMapping("/passenger")
 @RestController
 public class PassengerController {
 
-  private final PassengerUseCase passengerService;
-  @PostMapping("/new")
-  public ResponseEntity<CommonResponse> ride(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerCreateRequestDTO requestDTO) {
-    long memberId = Long.parseLong(userDetails.getUsername());
-    requestDTO.setMemberId(memberId);
-    passengerService.save(requestDTO);
+    private final PassengerUseCase passengerService;
 
-    CommonResponse res = CommonResponse.builder()
-            .status(HttpStatus.OK.value())
-            .message("탑승 신청이 완료되었습니다.")
-            .build();
-    return ResponseEntity.ok(res);
-  }
+    @Parameter(name = "passenger create", hidden = true)
+    @Operation(summary = "탑승자 생성", description = "특정 카풀에 탑승자를 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탑승 성공", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "자리가 만석이거나 이미 카풀에 탑승중인 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 카풀을 찾을 수 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/new")
+    public ResponseEntity<CommonResponse> ride(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerCreateRequestDTO requestDTO) {
+        long memberId = Long.parseLong(userDetails.getUsername());
+        requestDTO.setMemberId(memberId);
+        passengerService.save(requestDTO);
 
-  @PostMapping("/delete")
-  public ResponseEntity<String> delete(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerDeleteRequestDTO requestDTO) {
-    long memberId = Long.parseLong(userDetails.getUsername());
-    requestDTO.setMemberId(memberId);
-    passengerService.takeDown(requestDTO);
-    return ResponseEntity.ok("성공적으로 삭제가 되었습니다.");
-  }
+        CommonResponse res = CommonResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message("탑승 신청이 완료되었습니다.")
+                .build();
+        return ResponseEntity.ok(res);
+    }
+
+    @Parameter(name = "passenger delete", hidden = true)
+    @Operation(summary = "탑승자 삭제", description = "해당 카풀에서 특정 탑승자를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "404", description = "티켓을 찾을 수 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("")
+    public ResponseEntity<String> delete(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerDeleteRequestDTO requestDTO) {
+        long memberId = Long.parseLong(userDetails.getUsername());
+        requestDTO.setMemberId(memberId);
+        passengerService.takeDown(requestDTO);
+        return ResponseEntity.ok("성공적으로 삭제가 되었습니다.");
+    }
 }

--- a/src/main/java/com/example/eunboard/shared/config/Swagger2Config.java
+++ b/src/main/java/com/example/eunboard/shared/config/Swagger2Config.java
@@ -13,7 +13,7 @@ public class Swagger2Config {
     public GroupedOpenApi groupedOpenApi(){
         return GroupedOpenApi.builder().
                 group("v1-definition").
-                pathsToMatch("/auth/**", "/member/**", "/ticket/**") .build();
+                pathsToMatch("/auth/**", "/member/**", "/ticket/**", "/passenger/**") .build();
     }
 
     @Bean


### PR DESCRIPTION
- 기존에 탑승자 관련 API가 스웨거에서 조회가 안되는 상태였기에 현재 US7번을 작업하는 것에 있어서 문제가 발생 -> 조회가 되도록 수정 완료