### PR TITLE
fix : time regex를 잘못 설정해서 정상적인 입력값이 400 error를 반환하는 현상 해결

### DIFF
--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketCreateRequestDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketCreateRequestDto.java
@@ -28,12 +28,12 @@ public class TicketCreateRequestDto {
     // 탑승상세
     private String boardingPlace;
     // 월일 MMdd
-    @Pattern(regexp = "[0-1][0-9][0-3][0-9]")
+    @Pattern(regexp = "(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])")
     private String startDayMonth;
     // 오전오후
     private DayStatus dayStatus;
     // 출발시간 hhmm
-    @Pattern(regexp = "[0-2][0-9][0-5][0-9]")
+    @Pattern(regexp = "([0-1][0-9]|2[0-3])[0-5][0-9]")
     private String startTime;
     // 오픈채팅 url
     private String openChatUrl;

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketCreateRequestDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketCreateRequestDto.java
@@ -28,12 +28,12 @@ public class TicketCreateRequestDto {
     // 탑승상세
     private String boardingPlace;
     // 월일 MMdd
-    @Pattern(regexp = "[0-1][0-2][0-3][0-9]")
+    @Pattern(regexp = "[0-1][0-9][0-3][0-9]")
     private String startDayMonth;
     // 오전오후
     private DayStatus dayStatus;
     // 출발시간 hhmm
-    @Pattern(regexp = "[0-2][0-3][0-5][0-9]")
+    @Pattern(regexp = "[0-2][0-9][0-5][0-9]")
     private String startTime;
     // 오픈채팅 url
     private String openChatUrl;

--- a/src/test/java/com/example/eunboard/regex/RegexTest.java
+++ b/src/test/java/com/example/eunboard/regex/RegexTest.java
@@ -1,0 +1,32 @@
+package com.example.eunboard.regex;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class RegexTest {
+
+    @Test
+    @DisplayName(value = "날짜에 대한 문자열 테스트 코드")
+    public void startDayMonthRegexTest() {
+        String regex = "(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])";
+
+        assertThat("0900".matches(regex)).isEqualTo(false);
+        assertThat("0724".matches(regex)).isEqualTo(true);
+        assertThat("2400".matches(regex)).isEqualTo(false);
+        assertThat("2359".matches(regex)).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName(value = "시간에 대한 문자열 테스트 코드")
+    public void startStartTimeRegexTest() {
+        String regex = "([0-1][0-9]|2[0-3])[0-5][0-9]";
+
+        assertThat("0900".matches(regex)).isEqualTo(true);
+        assertThat("0724".matches(regex)).isEqualTo(true);
+        assertThat("2400".matches(regex)).isEqualTo(false);
+        assertThat("2359".matches(regex)).isEqualTo(true);
+    }
+}


### PR DESCRIPTION
### 문제 상황
- time에 관련된 string regex가 잘못 설정되어서 정상적인 시간 입력이 제대로 작동하지 않는 문제 발생
- [0-2][0-3][0-5][0-9] 와 같이 설정되어 있었는데 이렇게 되면 4~9시까지의 시간이 제대로 입력되지 않음

### 해결방안
- [0-2][0-9][0-5][0-9]로 변경하여 해결