### PR TITLE
Fix/ticket/detail

### DIFF
--- a/src/main/java/com/example/eunboard/passenger/application/port/in/PassengerDetailResponseDTO.java
+++ b/src/main/java/com/example/eunboard/passenger/application/port/in/PassengerDetailResponseDTO.java
@@ -1,0 +1,54 @@
+package com.example.eunboard.passenger.application.port.in;
+
+import com.example.eunboard.member.domain.Member;
+import com.example.eunboard.member.domain.MemberRole;
+import com.example.eunboard.passenger.domain.Passenger;
+import com.example.eunboard.shared.exception.ErrorCode;
+import com.example.eunboard.shared.exception.custom.CustomException;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PassengerDetailResponseDTO {
+    // 탑승자 번호
+    private Long passengerId;
+
+    // 탑승자에 대한 정보
+    private String email;
+
+    private String studentNumber;
+
+    private String memberName;
+
+    private String department;
+
+    private String phoneNumber;
+
+    private MemberRole auth;
+
+    private String profileImage;
+
+    private boolean isMember;
+
+    private String area;
+
+
+    public static PassengerDetailResponseDTO from(Passenger passenger) {
+        Member member = passenger.getMember();
+        if (member == null)
+            throw new CustomException("DTO 변환중에 탑승자에 해당하는 사용자 정보를 찾을 수 없었습니다.", ErrorCode.MEMBER_NOT_FOUND);
+        return PassengerDetailResponseDTO.builder()
+                .passengerId(passenger.getId())
+                .studentNumber(member.getStudentNumber())
+                .memberName(member.getMemberName())
+                .department(member.getDepartment())
+                .phoneNumber(member.getPhoneNumber())
+                .auth(member.getAuth())
+                .profileImage(member.getProfileImage())
+                .isMember(member.isMember())
+                .area(member.getArea())
+                .build();
+    }
+}

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.eunboard.ticket.application.port.in;
 
 import com.example.eunboard.member.application.port.in.MemberResponseDTO;
+import com.example.eunboard.passenger.application.port.in.PassengerDetailResponseDTO;
 import com.example.eunboard.passenger.domain.Passenger;
 import com.example.eunboard.ticket.domain.DayStatus;
 import com.example.eunboard.ticket.domain.Ticket;
@@ -46,7 +47,7 @@ public class TicketDetailResponseDto {
     // 현재 티켓의 상태
     private TicketStatus ticketStatus;
     // 탑승자 명단
-    private List<MemberResponseDTO> passengers;
+    private List<PassengerDetailResponseDTO> passengers;
 
     public static TicketDetailResponseDto toDTO(Ticket entity) {
         String startDayTime = entity.getStartDtime();
@@ -69,8 +70,7 @@ public class TicketDetailResponseDto {
                 .ticketStatus(entity.getStatus())
                 // 탑승자에 대한 정보를 변환해서 반환해야함.
                 .passengers(entity.getPassengerList().stream()
-                        .map(Passenger::getMember)
-                        .map((member -> MemberResponseDTO.toDTO(member, null)))
+                        .map(PassengerDetailResponseDTO::from)
                         .collect(Collectors.toList()))
                 .build();
     }


### PR DESCRIPTION
### 문제 상황
- passenger 를 삭제하기 위해서 pasenger id가 필요한데 해당 정보를 조회할 수 있는 API가 없습니다.

### 해결방안
- 기존에 Detail 조회와 자신의 카풀 조회 API에 탑승자 정보에서 passenger id를 조회할 수 있도록 추가하였습니다.