### PR TITLE
fix : 카풀의 드라이버가 탑승자를 강퇴하지 못하는 현상 해결

### DIFF
--- a/src/main/java/com/example/eunboard/passenger/adapter/in/PassengerController.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/in/PassengerController.java
@@ -50,13 +50,19 @@ public class PassengerController {
     @Parameter(name = "userDetails", hidden = true)
     @Operation(summary = "탑승자 삭제", description = "해당 카풀에서 특정 탑승자를 삭제합니다.")
     @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탑승자 삭제 완료", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "404", description = "티켓을 찾을 수 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @DeleteMapping("")
-    public ResponseEntity<String> delete(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerDeleteRequestDTO requestDTO) {
+    public ResponseEntity<CommonResponse> delete(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PassengerDeleteRequestDTO requestDTO) {
         long memberId = Long.parseLong(userDetails.getUsername());
         requestDTO.setMemberId(memberId);
-        passengerService.takeDown(requestDTO);
-        return ResponseEntity.ok("성공적으로 삭제가 되었습니다.");
+        passengerService.takeDown(memberId, requestDTO.getPassengerId(), requestDTO.getTicketId());
+
+        CommonResponse res = CommonResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message("탑승자가 성공적으로 삭제되었습니다.")
+                .build();
+        return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepository.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepository.java
@@ -4,6 +4,7 @@ import com.example.eunboard.member.domain.Member;
 import com.example.eunboard.passenger.domain.Passenger;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomPassengerRepository {
      boolean findRide(Passenger entity);
@@ -16,4 +17,6 @@ public interface CustomPassengerRepository {
      boolean existBoardingStatePassenger(Long memberId);
 
      Passenger findCurrentPassengerByMember(Member member);
+
+     Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId);
 }

--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepositoryImpl.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepositoryImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.example.eunboard.member.domain.QMember.member;
 import static com.example.eunboard.passenger.domain.QPassenger.passenger;
@@ -89,5 +90,15 @@ public class CustomPassengerRepositoryImpl implements CustomPassengerRepository{
             .where(passenger.ticket.status.eq(TicketStatus.BEFORE).and(passenger.ticket.status.eq(TicketStatus.ING)))
             .orderBy(passenger.ticket.createDate.desc())
             .fetchFirst();
+  }
+
+  @Override
+  public Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId) {
+    return Optional.ofNullable(queryFactory.select(passenger)
+            .from(passenger)
+            .where(passenger.ticket.id.eq(ticketId))
+            .where(passenger.id.eq(passengerId))
+            .orderBy(passenger.createDate.desc())
+            .fetchOne());
   }
 }

--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/PassengerRepositoryAdapter.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/PassengerRepositoryAdapter.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -48,5 +49,10 @@ public class PassengerRepositoryAdapter implements PassengerRepositoryPort {
     @Override
     public List<Passenger> findAllByTicket(Ticket ticket) {
         return passengerRepository.findAllByTicket(ticket);
+    }
+
+    @Override
+    public Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId) {
+        return passengerRepository.findByTicketIdAndPassengerId(ticketId, passengerId);
     }
 }

--- a/src/main/java/com/example/eunboard/passenger/application/port/in/PassengerUseCase.java
+++ b/src/main/java/com/example/eunboard/passenger/application/port/in/PassengerUseCase.java
@@ -3,5 +3,5 @@ package com.example.eunboard.passenger.application.port.in;
 public interface PassengerUseCase {
     void ride(PassengerCreateRequestDTO requestDTO);
 
-    void takeDown(PassengerDeleteRequestDTO requestDTO);
+    void takeDown(long requestMemberId, long targetPassengerId, long ticketId);
 }

--- a/src/main/java/com/example/eunboard/passenger/application/port/out/PassengerRepositoryPort.java
+++ b/src/main/java/com/example/eunboard/passenger/application/port/out/PassengerRepositoryPort.java
@@ -5,6 +5,7 @@ import com.example.eunboard.passenger.domain.Passenger;
 import com.example.eunboard.ticket.domain.Ticket;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PassengerRepositoryPort {
     Passenger save(Passenger passenger);
@@ -17,4 +18,6 @@ public interface PassengerRepositoryPort {
     Passenger findCurrentPassengerByMember(Member member);
 
     List<Passenger> findAllByTicket(Ticket ticket);
+
+    Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId);
 }

--- a/src/main/java/com/example/eunboard/passenger/application/service/PassengerService.java
+++ b/src/main/java/com/example/eunboard/passenger/application/service/PassengerService.java
@@ -48,7 +48,8 @@ public class PassengerService implements PassengerUseCase {
          * 티켓에 자리가 남았는지 체크
          */
         Ticket ticket = ticketRepositoryPort.findById(requestDTO.getTicketId()).orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
-        if (ticket.getPassengerList().size() == ticket.getRecruitPerson()) {
+
+        if (ticket.getPassengerList().stream().filter(passenger -> !passenger.isCancel()).count() == ticket.getRecruitPerson()) {
             throw new CustomException(ErrorCode.TICKET_IS_FULL.getMessage(), ErrorCode.TICKET_IS_FULL);
         }
         passengerRepository.save(PassengerCreateRequestDTO.toEntity(requestDTO));
@@ -67,14 +68,16 @@ public class PassengerService implements PassengerUseCase {
         Ticket ticket = ticketRepositoryPort
                 .findById(ticketId)
                 .orElseThrow(()-> new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
-        
+
         Passenger passenger = passengerRepository.findByTicketIdAndPassengerId(ticketId, targetPassengerId)
                 .orElseThrow(()-> new CustomException(ErrorCode.TICKET_PASS_NOT_FOUND.getMessage(), ErrorCode.TICKET_PASS_NOT_FOUND));
 
         switch(requestMember.getAuth()){
             case PASSENGER:
                 // 탑승자 memberId가 passengerId와 동일한지 확인
-                if(passenger.getMember().getMemberId().equals(requestMember.getMemberId())){
+                System.out.println(passenger.getMember().getMemberId());
+                System.out.println(requestMember.getMemberId());
+                if(!passenger.getMember().getMemberId().equals(requestMember.getMemberId())){
                     throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getErrorCode(), ErrorCode.MEMBER_NOT_AUTHORITY);
                 }
                 passenger.cancel();

--- a/src/main/java/com/example/eunboard/passenger/application/service/PassengerService.java
+++ b/src/main/java/com/example/eunboard/passenger/application/service/PassengerService.java
@@ -1,5 +1,7 @@
 package com.example.eunboard.passenger.application.service;
 
+import com.example.eunboard.member.application.port.out.MemberRepositoryPort;
+import com.example.eunboard.member.domain.Member;
 import com.example.eunboard.passenger.application.port.in.PassengerCreateRequestDTO;
 import com.example.eunboard.passenger.application.port.in.PassengerDeleteRequestDTO;
 import com.example.eunboard.passenger.application.port.in.PassengerUseCase;
@@ -14,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -22,6 +26,7 @@ public class PassengerService implements PassengerUseCase {
 
     private final PassengerRepositoryPort passengerRepository;
     private final TicketRepositoryPort ticketRepositoryPort;
+    private final MemberRepositoryPort memberRepository;
 
     /**
      * 탑승 가능한 적정 인원인지 체크 필요.
@@ -49,13 +54,39 @@ public class PassengerService implements PassengerUseCase {
         passengerRepository.save(PassengerCreateRequestDTO.toEntity(requestDTO));
     }
 
-    public void takeDown(PassengerDeleteRequestDTO requestDTO) {
-        Passenger entity = passengerRepository.findMyPassenger(PassengerDeleteRequestDTO.toEntity(requestDTO));
-        if (entity == null) {
-            throw new CustomException(ErrorCode.TICKET_PASS_NOT_FOUND.getMessage(), ErrorCode.TICKET_PASS_NOT_FOUND);
-        }
-        entity.setIsCancel(1);
-        passengerRepository.save(entity);
-    }
+    /**
+     *
+     * @param requestMemberId 탑승자를 지워달라고 요청을 보낸 사용자 id
+     * @param targetPassengerId 티켓에서 지워야하는 탑승자의 id
+     */
 
+    public void takeDown(long requestMemberId, long targetPassengerId, long ticketId) {
+        Member requestMember = memberRepository.findById(requestMemberId)
+                .orElseThrow(()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND.getMessage(), ErrorCode.MEMBER_NOT_FOUND));
+
+        Ticket ticket = ticketRepositoryPort
+                .findById(ticketId)
+                .orElseThrow(()-> new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
+        
+        Passenger passenger = passengerRepository.findByTicketIdAndPassengerId(ticketId, targetPassengerId)
+                .orElseThrow(()-> new CustomException(ErrorCode.TICKET_PASS_NOT_FOUND.getMessage(), ErrorCode.TICKET_PASS_NOT_FOUND));
+
+        switch(requestMember.getAuth()){
+            case PASSENGER:
+                // 탑승자 memberId가 passengerId와 동일한지 확인
+                if(passenger.getMember().getMemberId().equals(requestMember.getMemberId())){
+                    throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getErrorCode(), ErrorCode.MEMBER_NOT_AUTHORITY);
+                }
+                passenger.cancel();
+                break;
+            case DRIVER:
+                // 드라이버가 자신의 카풀이 맞는지 확인해야함.
+                if(!Objects.equals(ticket.getMember().getMemberId(), requestMember.getMemberId())){
+                    throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getErrorCode(), ErrorCode.MEMBER_NOT_AUTHORITY);
+                }
+                passenger.cancel(); // 현재 탑승자를 취소 상태 변경
+                break;
+            default:
+        }
+    }
 }

--- a/src/main/java/com/example/eunboard/passenger/domain/Passenger.java
+++ b/src/main/java/com/example/eunboard/passenger/domain/Passenger.java
@@ -42,6 +42,10 @@ public class Passenger extends BaseEntity {
     @ColumnDefault("'0'")
     private Integer isCancel;
 
+    public Boolean isCancel(){
+        return isCancel == 1;
+    }
+
     public void cancel() {
         isCancel = 1;
     }

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketDetailResponseDto.java
@@ -70,6 +70,7 @@ public class TicketDetailResponseDto {
                 .ticketStatus(entity.getStatus())
                 // 탑승자에 대한 정보를 변환해서 반환해야함.
                 .passengers(entity.getPassengerList().stream()
+                        .filter(passenger -> !passenger.isCancel())
                         .map(PassengerDetailResponseDTO::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/example/eunboard/ticket/application/port/in/TicketShortResponseDto.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/in/TicketShortResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.eunboard.ticket.application.port.in;
 
+import com.example.eunboard.passenger.domain.Passenger;
 import com.example.eunboard.ticket.domain.DayStatus;
 import com.example.eunboard.ticket.domain.Ticket;
 import com.example.eunboard.ticket.domain.TicketStatus;
@@ -42,7 +43,10 @@ public class TicketShortResponseDto {
                 .dayStatus(entity.getDayStatus())
                 .startTime(minuteHour)
                 .recruitPerson(entity.getRecruitPerson())
-                .currentPersonCount(entity.getPassengerList().size())
+                .currentPersonCount(
+                        (int) entity.getPassengerList().stream()
+                                .filter(passenger -> !passenger.isCancel())
+                                .count()) // 취소 되지 않은 내용만 개수를 세야한다.
                 .ticketStatus(entity.getStatus())
                 .ticketType(entity.getTicketType())
                 .build();


### PR DESCRIPTION
### 문제 상황
- 카풀의 드라이버가 자신의 카풀에 있는 사용자를 강퇴시키지 못하는 현상
- 탑승자가 자신의 카풀을 탑승 해제 하였지만 조회 내역에서는 여전히 탑승자 인원에 포함되는 현상
- 탑승자가 탑승해제 상태가 되었지만 여전히 ticket detail에 조회되는 현상

### 문제 해결
- 드라이버가 자신의 카풀에 속한 사람을 강퇴할 수 있도로구 수정
- 탑승 취소한 사람에 대하여 list, detail에서 조회되지 않도록 수정