### PR TITLE
feat, fix : 자신의 카풀 조회를 탑승자도 사용할 수 있게 변경, 기존의 드라이버 조회도 조회 쿼리로직 일부 개선

### DIFF
--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepository.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepository.java
@@ -19,4 +19,6 @@ public interface CustomPassengerRepository {
      Passenger findCurrentPassengerByMember(Member member);
 
      Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId);
+
+     Passenger findMyPassengerByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepositoryImpl.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/CustomPassengerRepositoryImpl.java
@@ -18,87 +18,110 @@ import static com.example.eunboard.ticket.domain.QTicket.ticket;
 
 @Transactional
 @RequiredArgsConstructor
-public class CustomPassengerRepositoryImpl implements CustomPassengerRepository{
+public class CustomPassengerRepositoryImpl implements CustomPassengerRepository {
 
-  private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-  private BooleanExpression eqMember(Member member){
-      return passenger.member.eq(member);
-  }
-  private BooleanExpression eqTicket(Ticket ticket) {return passenger.ticket.eq(ticket);}
+    private BooleanExpression eqMember(Member member) {
+        return passenger.member.eq(member);
+    }
 
-  /**
-   * member, ticket 같으며 cancel이 0 인 상태.
-   * 즉 탑승 신청이 완료된 상태
-   * @param entity
-   * @return
-   */
-  @Override
-  public boolean findRide(Passenger entity) {
-    return queryFactory
-        .selectFrom(passenger)
-        .where(eqMember(entity.getMember()),
-            eqTicket(entity.getTicket()),
-                passenger.isCancel.eq(0))
-        .fetch().size() > 0;
-    //passenger.isCancel.eq(0)
-  }
+    private BooleanExpression eqTicket(Ticket ticket) {
+        return passenger.ticket.eq(ticket);
+    }
 
-  @Override
-  public Passenger findMyPassenger(Passenger entity) {
-    return queryFactory
-        .selectFrom(passenger)
-        .leftJoin(passenger.member, member)
-        .fetchJoin()
-        .leftJoin(passenger.ticket, ticket)
-        .fetchJoin()
-        .where(eqMember(entity.getMember()),
-            passenger.id.eq(entity.getId()))
-        .fetchOne();
-  }
+    /**
+     * member, ticket 같으며 cancel이 0 인 상태.
+     * 즉 탑승 신청이 완료된 상태
+     *
+     * @param entity
+     * @return
+     */
+    @Override
+    public boolean findRide(Passenger entity) {
+        return queryFactory
+                .selectFrom(passenger)
+                .where(eqMember(entity.getMember()),
+                        eqTicket(entity.getTicket()),
+                        passenger.isCancel.eq(0))
+                .fetch().size() > 0;
+        //passenger.isCancel.eq(0)
+    }
 
-  @Override
-  public List<Passenger> getBoardingList(Long memberId) {
-    return queryFactory.selectFrom(passenger)
-            .leftJoin(passenger.member, member)
-            .fetchJoin()
-            .leftJoin(passenger.ticket, ticket)
-            .fetchJoin()
-            .where(passenger.member.memberId.eq(memberId),
-                    passenger.isCancel.eq(0))
-            .orderBy(passenger.ticket.createDate.desc())
-            .fetch();
-  }
+    @Override
+    public Passenger findMyPassenger(Passenger entity) {
+        return queryFactory
+                .selectFrom(passenger)
+                .leftJoin(passenger.member, member)
+                .fetchJoin()
+                .leftJoin(passenger.ticket, ticket)
+                .fetchJoin()
+                .where(eqMember(entity.getMember()),
+                        passenger.id.eq(entity.getId()))
+                .fetchOne();
+    }
 
-  @Override
-  public boolean existBoardingStatePassenger(Long memberId) {
-    // 현재 사용자가 탑승한 티켓이 있는지 확인하는 로직
-    return queryFactory.select(passenger)
-            .from(passenger)
-            .innerJoin(ticket).fetchJoin()
-            .on(passenger.ticket.id.eq(ticket.id)) //
-            .where(passenger.member.memberId.eq(memberId))
-            .where(passenger.isCancel.eq(0)).fetchOne() != null;
-  }
+    @Override
+    public List<Passenger> getBoardingList(Long memberId) {
+        return queryFactory.selectFrom(passenger)
+                .leftJoin(passenger.member, member)
+                .fetchJoin()
+                .leftJoin(passenger.ticket, ticket)
+                .fetchJoin()
+                .where(passenger.member.memberId.eq(memberId),
+                        passenger.isCancel.eq(0))
+                .orderBy(passenger.ticket.createDate.desc())
+                .fetch();
+    }
 
-  @Override
-  public Passenger findCurrentPassengerByMember(Member member) {
-    // 시간 역순으로 한뒤 가장 최근의 passenger 내역을 조회
-    return queryFactory.select(passenger)
-            .from(passenger)
-            .where(passenger.member.eq(member))
-            .where(passenger.ticket.status.eq(TicketStatus.BEFORE).and(passenger.ticket.status.eq(TicketStatus.ING)))
-            .orderBy(passenger.ticket.createDate.desc())
-            .fetchFirst();
-  }
+    @Override
+    public boolean existBoardingStatePassenger(Long memberId) {
+        // 현재 사용자가 탑승한 티켓이 있는지 확인하는 로직
+        return queryFactory.select(passenger)
+                .from(passenger)
+                .innerJoin(ticket).fetchJoin()
+                .on(passenger.ticket.id.eq(ticket.id)) //
+                .where(passenger.member.memberId.eq(memberId))
+                .where(passenger.isCancel.eq(0)).fetchOne() != null;
+    }
 
-  @Override
-  public Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId) {
-    return Optional.ofNullable(queryFactory.select(passenger)
-            .from(passenger)
-            .where(passenger.ticket.id.eq(ticketId))
-            .where(passenger.id.eq(passengerId))
-            .orderBy(passenger.createDate.desc())
-            .fetchOne());
-  }
+    @Override
+    public Passenger findCurrentPassengerByMember(Member member) {
+        // 시간 역순으로 한뒤 가장 최근의 passenger 내역을 조회
+        return queryFactory.select(passenger)
+                .from(passenger)
+                .where(passenger.member.eq(member))
+                .where(passenger.ticket.status.eq(TicketStatus.BEFORE).and(passenger.ticket.status.eq(TicketStatus.ING)))
+                .orderBy(passenger.ticket.createDate.desc())
+                .fetchFirst();
+    }
+
+    @Override
+    public Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId) {
+        return Optional.ofNullable(queryFactory.select(passenger)
+                .from(passenger)
+                .where(passenger.ticket.id.eq(ticketId))
+                .where(passenger.id.eq(passengerId))
+                .orderBy(passenger.createDate.desc())
+                .fetchOne());
+    }
+
+
+    /**
+     * 해당 로직은 'Passenger' 만 사용해야 합니다.
+     * Passenger가 탑승하고있는 카풀 중 BEFORE, ING 상태인 카풀 중 가장 최근 것을 '하나' 불러옵니다.
+     * @param memberId 현재 사용자 아이디(학번과 다름)
+     * @return 만약 카풀이 존재한다면 Passenger, 없다면 null
+     * @author tianea
+     */
+    @Override
+    public Passenger findMyPassengerByMemberId(Long memberId) {
+        return queryFactory.select(passenger)
+                .from(passenger)
+                .where(passenger.member.memberId.eq(memberId)) // 현재 탑승자와 사용자의 멤버 아이디가 같아야하고
+                .where(passenger.isCancel.eq(0)) // 탑승자가 취소된 상태가 아니여야함
+                .where(passenger.ticket.status.in(List.of(TicketStatus.BEFORE, TicketStatus.ING))) // 탑승한 티켓의 상태가 출발전이나 출발 도중이여야함.
+                .orderBy(passenger.createDate.desc())
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/example/eunboard/passenger/adapter/out/repository/PassengerRepositoryAdapter.java
+++ b/src/main/java/com/example/eunboard/passenger/adapter/out/repository/PassengerRepositoryAdapter.java
@@ -55,4 +55,9 @@ public class PassengerRepositoryAdapter implements PassengerRepositoryPort {
     public Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId) {
         return passengerRepository.findByTicketIdAndPassengerId(ticketId, passengerId);
     }
+
+    @Override
+    public Passenger findMyPassengerByMemberId(Long memberId) {
+        return passengerRepository.findMyPassengerByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/example/eunboard/passenger/application/port/out/PassengerRepositoryPort.java
+++ b/src/main/java/com/example/eunboard/passenger/application/port/out/PassengerRepositoryPort.java
@@ -20,4 +20,6 @@ public interface PassengerRepositoryPort {
     List<Passenger> findAllByTicket(Ticket ticket);
 
     Optional<Passenger> findByTicketIdAndPassengerId(long ticketId, long passengerId);
+
+    Passenger findMyPassengerByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/in/TicketController.java
@@ -108,8 +108,6 @@ public class TicketController {
     @GetMapping("/promise")
     public TicketDetailResponseDto promise(@AuthenticationPrincipal UserDetails userDetails) {
         long memberId = Long.parseLong(userDetails.getUsername());
-        if (!memberUseCase.checkRole(memberId))
-            throw new CustomException(ErrorCode.MEMBER_NOT_AUTHORITY.getMessage(), ErrorCode.MEMBER_NOT_AUTHORITY);
         return ticketService.getPromise(memberId);
     }
 

--- a/src/main/java/com/example/eunboard/ticket/adapter/out/repository/CustomTicketRepository.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/out/repository/CustomTicketRepository.java
@@ -14,4 +14,6 @@ public interface CustomTicketRepository {
      List<Ticket> getAvailableList();
      List<Ticket> getRecentTickets(Long memberId);
      boolean existTicket(Long memberId);
+
+     Ticket findMyTicketByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/ticket/adapter/out/repository/CustomTicketRepositoryImpl.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/out/repository/CustomTicketRepositoryImpl.java
@@ -104,5 +104,22 @@ public class CustomTicketRepositoryImpl implements CustomTicketRepository {
                         .and(ticket.member.memberId.eq(memberId)))
                 .fetchOne() != null;
     }
+
+    /**
+     * 해당 로직은 '드라이버'만 사용해야 합니다.
+     * 드라이버가 가지고 있는 카풀 중 BEFORE, ING 상태인 카풀 중 가장 최근 것을 불러옵니다.
+     * @param memberId 현재 사용자 아이디(학번과 다름)
+     * @return 만약 카풀이 존재한다면 Ticket, 없다면 null
+     * @author tianea
+     */
+    @Override
+    public Ticket findMyTicketByMemberId(Long memberId) {
+        return queryFactory.select(ticket)
+                .from(ticket)
+                .where(ticket.member.memberId.eq(memberId))
+                .where(ticket.status.in(List.of(TicketStatus.BEFORE, TicketStatus.ING)))
+                .orderBy(ticket.createDate.desc())
+                .fetchFirst();
+    }
 }
 

--- a/src/main/java/com/example/eunboard/ticket/adapter/out/repository/TicketRepositoryAdapter.java
+++ b/src/main/java/com/example/eunboard/ticket/adapter/out/repository/TicketRepositoryAdapter.java
@@ -54,4 +54,9 @@ public class TicketRepositoryAdapter implements TicketRepositoryPort {
     public boolean existTicket(Long memberId) {
         return ticketRepository.existTicket(memberId);
     }
+
+    @Override
+    public Ticket findMyTicketByMemberId(Long memberId) {
+        return ticketRepository.findMyTicketByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/example/eunboard/ticket/application/port/out/TicketRepositoryPort.java
+++ b/src/main/java/com/example/eunboard/ticket/application/port/out/TicketRepositoryPort.java
@@ -16,4 +16,6 @@ public interface TicketRepositoryPort {
     /** US-10 */
     List<Ticket> getRecentList(Long memberId);
     boolean existTicket(Long memberId);
+
+    Ticket findMyTicketByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
+++ b/src/main/java/com/example/eunboard/ticket/application/service/TicketService.java
@@ -2,6 +2,8 @@ package com.example.eunboard.ticket.application.service;
 
 import com.example.eunboard.member.application.port.out.MemberRepositoryPort;
 import com.example.eunboard.member.domain.Member;
+import com.example.eunboard.passenger.application.port.out.PassengerRepositoryPort;
+import com.example.eunboard.passenger.domain.Passenger;
 import com.example.eunboard.shared.exception.ErrorCode;
 import com.example.eunboard.shared.exception.custom.CustomException;
 import com.example.eunboard.ticket.application.port.in.TicketCreateRequestDto;
@@ -28,13 +30,14 @@ import java.util.stream.Collectors;
 public class TicketService implements TicketUseCase {
     private final TicketRepositoryPort ticketRepository;
     private final MemberRepositoryPort memberRepository;
+    private final PassengerRepositoryPort passengerRepository;
 
     @Override
     public void createCarPool(TicketCreateRequestDto requestDto) {
         // 시간 체크
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime todayMorning = now.toLocalDate().atTime(9,30);
-        LocalDateTime yesterdayNight = now.toLocalDate().atTime(21,0).minusDays(1);
+        LocalDateTime todayMorning = now.toLocalDate().atTime(9, 30);
+        LocalDateTime yesterdayNight = now.toLocalDate().atTime(21, 0).minusDays(1);
 
         LocalDateTime todayNight = now.toLocalDate().atTime(21, 0);
         LocalDateTime tomorrowMorning = now.toLocalDate().plusDays(1).atTime(9, 30);
@@ -44,7 +47,7 @@ public class TicketService implements TicketUseCase {
 //            throw new CustomException(ErrorCode.NOT_PERMITTED_TIME.getMessage(), ErrorCode.NOT_PERMITTED_TIME);
 
         boolean existTicket = ticketRepository.existTicket(requestDto.getMemberId());
-        if (existTicket){
+        if (existTicket) {
             throw new CustomException(ErrorCode.TICKET_IS_EXIST.getMessage(), ErrorCode.TICKET_IS_EXIST);
         }
         Ticket ticket = TicketCreateRequestDto.toEntity(requestDto);
@@ -61,32 +64,64 @@ public class TicketService implements TicketUseCase {
     // 티켓 상세보기
     @Override
     public TicketDetailResponseDto readTicket(Long id) {
-        Ticket ticket = ticketRepository.findById(id).orElseThrow(()->new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
+        Ticket ticket = ticketRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
         return TicketDetailResponseDto.toDTO(ticket);
     }
 
     // 티켓 상태 업데이트
     @Override
     public void ticketStatusUpdate(long memberId, long id, TicketStatus status) {
-        Ticket ticket = ticketRepository.findById(id).orElseThrow(()->new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
+        Ticket ticket = ticketRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND));
         // 정보 업데이트 후 저장
         ticket.updateStatus(status);
         ticketRepository.save(ticket);
     }
 
+    /**
+     * <pre>
+     *     해당 메소드는 사용자의 현재 카풀을 조회하는 로직입니다.
+     *     드라이버의 경우 자신이 생성한 카풀 중에서 취소되거나 완료되지 않은 카풀을 '하나' 조회가능
+     *     탑승자의 경우, 자신이 탑승하고 있는 카풀중에서 카풀이 취소되거나, 자신이 탑승을 취소한 경우를 제외한 '하나'를 조회가능합니다.
+     *     만약 해당하는 값이 하나도 없다면 예외를 발생시킵니다.
+     * </pre>
+     * @param memberId 자신의 현재 카풀을 조회하고 싶은 사용자의 아이디
+     * @return
+     * Driver -> 자신이 생성한 카풀,
+     * Passenger -> 자신이 현재 탑승하고 있는 카풀
+     * 만약 해당하는 정보를 찾지 못한 경우 exception
+     */
     @Override
     public TicketDetailResponseDto getPromise(Long memberId) {
-        Ticket ticket = ticketRepository.findByMember(Member.builder().memberId(memberId).build());
 
-        if (ticket == null) {
-            throw new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND.getMessage(), ErrorCode.MEMBER_NOT_FOUND));
+
+        Ticket ticket = null;
+
+        switch (member.getAuth()) {
+            case PASSENGER:
+                Passenger passenger = passengerRepository.findMyPassengerByMemberId(member.getMemberId());
+
+                if (passenger == null)
+                    throw new CustomException(ErrorCode.TICKET_PASS_NOT_FOUND.getMessage(), ErrorCode.TICKET_PASS_NOT_FOUND);
+
+                ticket = passenger.getTicket();
+                break;
+            case DRIVER:
+                ticket = ticketRepository.findMyTicketByMemberId(member.getMemberId());
+
+                if (ticket == null)
+                    throw new CustomException(ErrorCode.TICKET_NOT_FOUND.getMessage(), ErrorCode.TICKET_NOT_FOUND);
+                break;
+            default:
+                throw new IllegalStateException("해당 상황에서 이 api를 지원하지 않습니다.");
         }
-        
         return TicketDetailResponseDto.toDTO(ticket);
     }
 
     /**
      * 카풀 만약 여러개 운행이 가능하다면
+     *
      * @param memberId
      * @return
      */


### PR DESCRIPTION
### 요구사항
- 기존에 있던 자신의 카풀 조회 로직은 드라이버만 사용가능하였습니다. 하지만 해당 로직을 탑승자도 사용가능하도록 변경 요청(/ticket/promise)

### 진행 사항
- 탑승자도 자신의 카풀을 조회할 수 있도록 수정 완료
- 드라이버의 자신의 카풀 조회 쿼리 로직도 일부 수정